### PR TITLE
feat: specify type for cefactBieDomainClass

### DIFF
--- a/scripts/transformer/src/main/java/org/unece/uncefact/vocab/Transformer.java
+++ b/scripts/transformer/src/main/java/org/unece/uncefact/vocab/Transformer.java
@@ -56,7 +56,7 @@ public abstract class Transformer {
     protected void setContext (){
         contextObjectBuilder = Json.createObjectBuilder();
         //common context for all vocabularies
-        contextObjectBuilder.add(UNECE_NS, "https://service.unece.org/trade/uncefact/trade/uncefact/vocabulary/unece#");
+        contextObjectBuilder.add(UNECE_NS, "https://service.unece.org/trade/uncefact/vocabulary/unece#");
         contextObjectBuilder.add(RDF_NS, "http://www.w3.org/1999/02/22-rdf-syntax-ns#");
         contextObjectBuilder.add(RDFS_NS, "http://www.w3.org/2000/01/rdf-schema#");
     }

--- a/scripts/transformer/src/main/java/org/unece/uncefact/vocab/transformers/BSPToJSONLDVocabulary.java
+++ b/scripts/transformer/src/main/java/org/unece/uncefact/vocab/transformers/BSPToJSONLDVocabulary.java
@@ -35,11 +35,17 @@ public class BSPToJSONLDVocabulary extends WorkBookTransformer {
 
     public BSPToJSONLDVocabulary(String inputFile, String outputFile, boolean prettyPrint) {
         super(inputFile, outputFile,prettyPrint);
+    }
+
+    protected void setContext (){
+        super.setContext();
 
         contextObjectBuilder.add(SCHEMA_NS, "http://schema.org/");
-        contextObjectBuilder.add(UNECE_NS, "https://service.unece.org/trade/uncefact/trade/uncefact/vocabulary/unece#");
         contextObjectBuilder.add(CEFACT_NS, "https://edi3.org/cefact#");
         contextObjectBuilder.add(XSD_NS, "http://www.w3.org/2001/XMLSchema#");
+        JsonObjectBuilder objectBuilder = Json.createObjectBuilder();
+        objectBuilder.add(TYPE, ID);
+        contextObjectBuilder.add(UNECE_CEFACT_BIE_DOMAIN_CLASS, objectBuilder.build());
     }
 
     public void readInputFileToGraphArray(final Object object) {


### PR DESCRIPTION
ref #36 
This PR adds a type for `unece:cefactBieDomainClass` attribute:
```
{
    "@context": {
        "unece": "https://service.unece.org/trade/uncefact/vocabulary/unece#",
        "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
        "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
        "schema": "http://schema.org/",
        "cefact": "https://edi3.org/cefact#",
        "xsd": "http://www.w3.org/2001/XMLSchema#",
        "unece:cefactBieDomainClass": {
            "@type": "@id"
        }
    },
    "@graph": [
    ...
    ]
}
```