### PR TITLE
Fix: adjust properties names when the type is different

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -2,8 +2,31 @@ Transform scripts go here.
 
 Transformation tool is a java program, binary is released as a jar file and can be run with the following command:
 ```
-java -jar vocab-transformer.jar -i "path_to_input_file.xls"
+java -jar vocab-transformer.jar -?
 ```
-To get help run the jar with the option `?`
+The option `-?` will list the available types for transformation:
 
-To get the latest version from main branch go to https://github.com/uncefact/vocab/actions/workflows/package.yml and checkout the artifcats for the latest run. The complete release process to be set up soon.
+- `unece` - the default type to transform BSP subset from XLS input file and text file with UNCL code lists.
+- `rec20` - produces the output for Recommendation 20
+- `rec21` - produces the output for Recommendation 21
+- `rec24` - produces the output for Recommendation 24
+- `rec28` - produces the output for Recommendation 24
+- `unlcd` - UN/LOCODE output generation
+
+<i>Please note that UN/LOCODE is big set of data, and it takes time and resource to produce the output. 
+The size of the output file is about 40Mb.</i>
+
+By default, the input data is taken from the src/main/resources directory, but you can override the input files with `-i` option:
+
+```
+java -jar vocab-transformer.jar -t rec20 -i /path/to/your/file
+```
+
+But keep in mind the file format and data structure should be the same as for the default input files.
+
+The output files are the JSON-LD vocabulry definitions along with context files.
+Currently, we have two contexts:
+- `unece` for BSP subset and code lists
+- `unlcd` for UN/LOCODEs
+
+To get the latest version from main branch go to https://github.com/uncefact/vocab/actions/workflows/package.yml and checkout the artifacts for the latest run. The complete release process to be set up soon.

--- a/scripts/transformer/pom.xml
+++ b/scripts/transformer/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>org.unece.uncefact</groupId>
     <artifactId>vocab-transformer</artifactId>
-    <version>1.0.0-rc7</version>
+    <version>1.0.0-rc8</version>
     <build>
         <plugins>
             <plugin>

--- a/scripts/transformer/pom.xml
+++ b/scripts/transformer/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>org.unece.uncefact</groupId>
     <artifactId>vocab-transformer</artifactId>
-    <version>1.0.0-rc8</version>
+    <version>1.0.0-rc9</version>
     <build>
         <plugins>
             <plugin>

--- a/scripts/transformer/src/main/java/org/unece/uncefact/vocab/Entity.java
+++ b/scripts/transformer/src/main/java/org/unece/uncefact/vocab/Entity.java
@@ -2,10 +2,7 @@ package org.unece.uncefact.vocab;
 
 import org.apache.commons.lang3.StringUtils;
 
-import java.util.Arrays;
-import java.util.List;
-import java.util.Set;
-import java.util.TreeSet;
+import java.util.*;
 
 public class Entity {
     /**

--- a/scripts/transformer/src/main/java/org/unece/uncefact/vocab/FileEntity.java
+++ b/scripts/transformer/src/main/java/org/unece/uncefact/vocab/FileEntity.java
@@ -1,0 +1,4 @@
+package org.unece.uncefact.vocab;
+
+public interface FileEntity {
+}

--- a/scripts/transformer/src/main/java/org/unece/uncefact/vocab/FileGenerator.java
+++ b/scripts/transformer/src/main/java/org/unece/uncefact/vocab/FileGenerator.java
@@ -15,7 +15,9 @@ public class FileGenerator {
                              final JsonArrayBuilder graphJsonArrayBuilder, boolean prettyPrint, String outputFile) {
         JsonObjectBuilder jsonObjectBuilder = Json.createObjectBuilder();
         jsonObjectBuilder.add("@context", contextObjectBuilder.build());
-        jsonObjectBuilder.add("@graph", graphJsonArrayBuilder.build());
+        if (graphJsonArrayBuilder!=null) {
+            jsonObjectBuilder.add("@graph", graphJsonArrayBuilder.build());
+        }
 
         Map<String, Boolean> config = new HashMap<>();
         if (prettyPrint) {
@@ -23,7 +25,7 @@ public class FileGenerator {
         }
         StringWriter stringWriter = new StringWriter();
         JsonWriterFactory writerFactory = Json.createWriterFactory(config);
-        ;
+
         try (JsonWriter jsonWriter = writerFactory.createWriter(stringWriter)) {
             jsonWriter.writeObject(jsonObjectBuilder.build());
         }

--- a/scripts/transformer/src/main/java/org/unece/uncefact/vocab/JSONLDContext.java
+++ b/scripts/transformer/src/main/java/org/unece/uncefact/vocab/JSONLDContext.java
@@ -1,0 +1,47 @@
+package org.unece.uncefact.vocab;
+
+import javax.json.Json;
+import javax.json.JsonArrayBuilder;
+import javax.json.JsonObjectBuilder;
+
+public class JSONLDContext implements FileEntity{
+    protected JsonObjectBuilder contextObjectBuilder;
+
+    protected String outputFile;
+
+    protected boolean prettyPrint;
+
+    public JSONLDContext() {
+        contextObjectBuilder = Json.createObjectBuilder();
+    }
+
+    public JSONLDContext(String outputFile, boolean prettyPrint) {
+        this();
+        this.outputFile = outputFile;
+        this.prettyPrint = prettyPrint;
+    }
+
+    public JsonObjectBuilder getContextObjectBuilder() {
+        return contextObjectBuilder;
+    }
+
+    public void setContextObjectBuilder(JsonObjectBuilder contextObjectBuilder) {
+        this.contextObjectBuilder = contextObjectBuilder;
+    }
+
+    public String getOutputFile() {
+        return outputFile;
+    }
+
+    public void setOutputFile(String outputFile) {
+        this.outputFile = outputFile;
+    }
+
+    public boolean isPrettyPrint() {
+        return prettyPrint;
+    }
+
+    public void setPrettyPrint(boolean prettyPrint) {
+        this.prettyPrint = prettyPrint;
+    }
+}

--- a/scripts/transformer/src/main/java/org/unece/uncefact/vocab/JSONLDVocabulary.java
+++ b/scripts/transformer/src/main/java/org/unece/uncefact/vocab/JSONLDVocabulary.java
@@ -1,0 +1,58 @@
+package org.unece.uncefact.vocab;
+
+import javax.json.Json;
+import javax.json.JsonArrayBuilder;
+import javax.json.JsonObjectBuilder;
+
+public class JSONLDVocabulary implements FileEntity{
+    protected JsonArrayBuilder graphJsonArrayBuilder;
+
+    protected JsonObjectBuilder contextObjectBuilder;
+
+    protected String outputFile;
+
+    protected boolean prettyPrint;
+
+    public JSONLDVocabulary() {
+        graphJsonArrayBuilder = Json.createArrayBuilder();
+        contextObjectBuilder = Json.createObjectBuilder();
+    }
+
+    public JSONLDVocabulary(String outputFile, boolean prettyPrint) {
+        this();
+        this.outputFile = outputFile;
+        this.prettyPrint = prettyPrint;
+    }
+
+    public JsonArrayBuilder getGraphJsonArrayBuilder() {
+        return graphJsonArrayBuilder;
+    }
+
+    public void setGraphJsonArrayBuilder(JsonArrayBuilder graphJsonArrayBuilder) {
+        this.graphJsonArrayBuilder = graphJsonArrayBuilder;
+    }
+
+    public JsonObjectBuilder getContextObjectBuilder() {
+        return contextObjectBuilder;
+    }
+
+    public void setContextObjectBuilder(JsonObjectBuilder contextObjectBuilder) {
+        this.contextObjectBuilder = contextObjectBuilder;
+    }
+
+    public String getOutputFile() {
+        return outputFile;
+    }
+
+    public void setOutputFile(String outputFile) {
+        this.outputFile = outputFile;
+    }
+
+    public boolean isPrettyPrint() {
+        return prettyPrint;
+    }
+
+    public void setPrettyPrint(boolean prettyPrint) {
+        this.prettyPrint = prettyPrint;
+    }
+}

--- a/scripts/transformer/src/main/java/org/unece/uncefact/vocab/transformers/REC20ToJSONLDVocabulary.java
+++ b/scripts/transformer/src/main/java/org/unece/uncefact/vocab/transformers/REC20ToJSONLDVocabulary.java
@@ -1,21 +1,35 @@
 package org.unece.uncefact.vocab.transformers;
 
 import org.apache.commons.lang3.StringUtils;
+import org.apache.poi.openxml4j.exceptions.InvalidFormatException;
 import org.apache.poi.ss.usermodel.Row;
 import org.apache.poi.ss.usermodel.Sheet;
 import org.apache.poi.ss.usermodel.Workbook;
+import org.apache.poi.ss.usermodel.WorkbookFactory;
+import org.unece.uncefact.vocab.JSONLDVocabulary;
+import org.unece.uncefact.vocab.Transformer;
 
 import javax.json.*;
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.nio.charset.Charset;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.util.*;
 
 public class REC20ToJSONLDVocabulary extends WorkBookTransformer {
 
-    public REC20ToJSONLDVocabulary(String inputFile, String outputFile, boolean prettyPrint) {
-        super(inputFile, outputFile, prettyPrint);
-        contextObjectBuilder.add(REC20_NS, NS_MAP.get(REC20_NS));
+    public REC20ToJSONLDVocabulary(String inputFile, String defaultFile) {
+        super(inputFile, defaultFile);
     }
 
     public void readInputFileToGraphArray(final Object object) {
+        JSONLDVocabulary JSONLDVocabulary = new JSONLDVocabulary(StringUtils.join(REC20_NS, ".jsonld"), true);
+        JSONLDVocabulary.setContextObjectBuilder(getContext());
+        JSONLDVocabulary.getContextObjectBuilder().add(REC20_NS, NS_MAP.get(REC20_NS));
+
         Workbook workbook = (Workbook) object;
         Sheet sheet = workbook.getSheetAt(2);
         Iterator<Row> rowIterator = sheet.rowIterator();
@@ -56,8 +70,9 @@ public class REC20ToJSONLDVocabulary extends WorkBookTransformer {
                 rdfClass.add(StringUtils.join(UNECE_NS,":","conversionFactor"), conversionFactor);
             if (StringUtils.isNotEmpty(status))
                 rdfClass.add(StringUtils.join(UNECE_NS,":","status"), status);
-            graphJsonArrayBuilder.add(rdfClass);
+            JSONLDVocabulary.getGraphJsonArrayBuilder().add(rdfClass);
         }
+        vocabularies.add(JSONLDVocabulary);
     }
 
 }

--- a/scripts/transformer/src/main/java/org/unece/uncefact/vocab/transformers/REC21ToJSONLDVocabulary.java
+++ b/scripts/transformer/src/main/java/org/unece/uncefact/vocab/transformers/REC21ToJSONLDVocabulary.java
@@ -1,25 +1,33 @@
 package org.unece.uncefact.vocab.transformers;
 
 import org.apache.commons.lang3.StringUtils;
+import org.apache.poi.openxml4j.exceptions.InvalidFormatException;
 import org.apache.poi.ss.usermodel.Row;
 import org.apache.poi.ss.usermodel.Sheet;
 import org.apache.poi.ss.usermodel.Workbook;
+import org.apache.poi.ss.usermodel.WorkbookFactory;
+import org.unece.uncefact.vocab.JSONLDVocabulary;
+import org.unece.uncefact.vocab.Transformer;
 
 import javax.json.Json;
 import javax.json.JsonObjectBuilder;
+import java.io.File;
+import java.io.IOException;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Set;
 
 public class REC21ToJSONLDVocabulary extends WorkBookTransformer {
 
-    public REC21ToJSONLDVocabulary(String inputFile, String outputFile, boolean prettyPrint) {
-        super(inputFile, outputFile, prettyPrint);
-
-        contextObjectBuilder.add(REC21_NS, NS_MAP.get(REC21_NS));
+    public REC21ToJSONLDVocabulary(String inputFile, String defaultFile) {
+        super(inputFile, defaultFile);
     }
 
     public void readInputFileToGraphArray(final Object object) {
+        JSONLDVocabulary JSONLDVocabulary = new JSONLDVocabulary(StringUtils.join(REC21_NS, ".jsonld"), true);
+        JSONLDVocabulary.setContextObjectBuilder(getContext());
+        JSONLDVocabulary.getContextObjectBuilder().add(REC21_NS, NS_MAP.get(REC21_NS));
+
         Workbook workbook = (Workbook) object;
         Sheet sheet = workbook.getSheetAt(0);
         Iterator<Row> rowIterator = sheet.rowIterator();
@@ -55,8 +63,9 @@ public class REC21ToJSONLDVocabulary extends WorkBookTransformer {
             /* there are only two codes with the status defined, guess we can ignore it
             if (StringUtils.isNotEmpty(status))
                 rdfClass.add(StringUtils.join(UNECE_NS,":","status"), status);*/
-            graphJsonArrayBuilder.add(rdfClass);
+            JSONLDVocabulary.getGraphJsonArrayBuilder().add(rdfClass);
         }
+        vocabularies.add(JSONLDVocabulary);
     }
 
 }

--- a/scripts/transformer/src/main/java/org/unece/uncefact/vocab/transformers/REC24ToJSONLDVocabulary.java
+++ b/scripts/transformer/src/main/java/org/unece/uncefact/vocab/transformers/REC24ToJSONLDVocabulary.java
@@ -1,25 +1,33 @@
 package org.unece.uncefact.vocab.transformers;
 
 import org.apache.commons.lang3.StringUtils;
+import org.apache.poi.openxml4j.exceptions.InvalidFormatException;
 import org.apache.poi.ss.usermodel.Row;
 import org.apache.poi.ss.usermodel.Sheet;
 import org.apache.poi.ss.usermodel.Workbook;
+import org.apache.poi.ss.usermodel.WorkbookFactory;
+import org.unece.uncefact.vocab.JSONLDVocabulary;
+import org.unece.uncefact.vocab.Transformer;
 
 import javax.json.Json;
 import javax.json.JsonObjectBuilder;
+import java.io.File;
+import java.io.IOException;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Set;
 
 public class REC24ToJSONLDVocabulary extends WorkBookTransformer {
 
-    public REC24ToJSONLDVocabulary(String inputFile, String outputFile, boolean prettyPrint) {
-        super(inputFile, outputFile, prettyPrint);
-
-        contextObjectBuilder.add(REC24_NS, NS_MAP.get(REC24_NS));
+    public REC24ToJSONLDVocabulary(String inputFile, String defaultFile) {
+        super(inputFile, defaultFile);
     }
 
     public void readInputFileToGraphArray(final Object object) {
+        JSONLDVocabulary JSONLDVocabulary = new JSONLDVocabulary(StringUtils.join(REC24_NS, ".jsonld"), true);
+        JSONLDVocabulary.setContextObjectBuilder(getContext());
+        JSONLDVocabulary.getContextObjectBuilder().add(REC24_NS, NS_MAP.get(REC24_NS));
+
         Workbook workbook = (Workbook) object;
         Sheet sheet = workbook.getSheetAt(0);
         Iterator<Row> rowIterator = sheet.rowIterator();
@@ -46,8 +54,9 @@ public class REC24ToJSONLDVocabulary extends WorkBookTransformer {
             rdfClass.add(RDFS_COMMENT, description);
             rdfClass.add(RDFS_LABEL, name);
             rdfClass.add(RDF_VALUE, code);
-            graphJsonArrayBuilder.add(rdfClass);
+            JSONLDVocabulary.getGraphJsonArrayBuilder().add(rdfClass);
         }
+        vocabularies.add(JSONLDVocabulary);
     }
 
 }

--- a/scripts/transformer/src/main/java/org/unece/uncefact/vocab/transformers/REC28ToJSONLDVocabulary.java
+++ b/scripts/transformer/src/main/java/org/unece/uncefact/vocab/transformers/REC28ToJSONLDVocabulary.java
@@ -4,6 +4,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.poi.ss.usermodel.Row;
 import org.apache.poi.ss.usermodel.Sheet;
 import org.apache.poi.ss.usermodel.Workbook;
+import org.unece.uncefact.vocab.JSONLDVocabulary;
 
 import javax.json.Json;
 import javax.json.JsonObjectBuilder;
@@ -12,13 +13,16 @@ import java.util.Iterator;
 import java.util.Set;
 
 public class REC28ToJSONLDVocabulary extends WorkBookTransformer {
-    public REC28ToJSONLDVocabulary(String inputFile, String outputFile, boolean prettyPrint) {
-        super(inputFile, outputFile, prettyPrint);
 
-        contextObjectBuilder.add(REC28_NS, NS_MAP.get(REC28_NS));
+    public REC28ToJSONLDVocabulary(String inputFile, String defaultFile) {
+        super(inputFile, defaultFile);
     }
 
     public void readInputFileToGraphArray(final Object object) {
+        JSONLDVocabulary JSONLDVocabulary = new JSONLDVocabulary(StringUtils.join(REC28_NS, ".jsonld"), true);
+        JSONLDVocabulary.setContextObjectBuilder(getContext());
+        JSONLDVocabulary.getContextObjectBuilder().add(REC28_NS, NS_MAP.get(REC28_NS));
+
         Workbook workbook = (Workbook) object;
         Sheet sheet = workbook.getSheetAt(0);
         Iterator<Row> rowIterator = sheet.rowIterator();
@@ -49,8 +53,9 @@ public class REC28ToJSONLDVocabulary extends WorkBookTransformer {
             rdfClass.add(RDFS_COMMENT, description);
             rdfClass.add(RDFS_LABEL, name);
             rdfClass.add(RDF_VALUE, code);
-            graphJsonArrayBuilder.add(rdfClass);
+            JSONLDVocabulary.getGraphJsonArrayBuilder().add(rdfClass);
         }
+        vocabularies.add(JSONLDVocabulary);
     }
 
 }

--- a/scripts/transformer/src/main/java/org/unece/uncefact/vocab/transformers/WorkBookTransformer.java
+++ b/scripts/transformer/src/main/java/org/unece/uncefact/vocab/transformers/WorkBookTransformer.java
@@ -7,14 +7,21 @@ import org.unece.uncefact.vocab.Transformer;
 
 import java.io.File;
 import java.io.IOException;
+import java.io.InputStream;
 
 public abstract class WorkBookTransformer extends Transformer {
-    protected WorkBookTransformer(String inputFile, String outputFile, boolean prettyPrint) {
-        super(inputFile, outputFile, prettyPrint);
+
+    public WorkBookTransformer(String inputFile, String defaultFile) {
+        super(inputFile, defaultFile);
     }
 
     public void transform() throws IOException, InvalidFormatException {
-        Workbook workbook = WorkbookFactory.create(new File(inputFile));
+        Workbook workbook;
+        if (inputFile == null){
+            workbook = WorkbookFactory.create(getClass().getResourceAsStream(defaultFile));
+        } else {
+            workbook = WorkbookFactory.create(new File(inputFile));
+        }
         readInputFileToGraphArray(workbook);
         super.transform();
     }


### PR DESCRIPTION
fixes #139 

Some properties were grouped by the same name when they had different type (rangeIncludes). That caused the problem described in #139 issue

Diff report for the outputs produced by this fix against the currently published version:
```
Classes that exists in set1 but missing in set2 (were removed from set2) - 0:
Classes that exists in set2 but missing in set1 (were added to set2) - 0:
Properties that exists in set1 but missing in set2 (were removed from set2) - 0:
Properties that exists in set2 but missing in set1 (were added to set2) - 37:
unece:applicableLineTradeAgreement
unece:applicableLineTradeDelivery
unece:applicableReturnableAssetInstructions
unece:applicableTransportSettingTemperature
unece:associatedDocumentLineDocument
unece:associatedFinancingRequestResultDocument
unece:attachedAttachedTransportEquipment
unece:categoryAppliedTax
unece:definedOperationalParameter
unece:deliverySupplyChainEvent
unece:emailURIEmailCommunication
unece:faxTelecommunicationCommunication
unece:previousDeliveryTransportEvent
unece:providerTradeParty
unece:specifiedAdvancePayment
unece:specifiedAuthoritativeSignatoryPerson
unece:specifiedCancellationStatus
unece:specifiedDebtorFinancialAccount
unece:specifiedDeliveryInstructions
unece:specifiedEmployerIdentity
unece:specifiedFinancialIdentity
unece:specifiedFinancingStatus
unece:specifiedGovernmentRegistration
unece:specifiedLineTradeAgreement
unece:specifiedLineTradeSettlement
unece:specifiedPersonIdentity
unece:specifiedProjectPerson
unece:specifiedSubordinateLineTradeDelivery
unece:specifiedSubordinateLineTradeSettlement
unece:specifiedSupplyChainEvent
unece:specifiedTradeSettlementLineMonetarySummation
unece:specifiedTradeSettlementPaymentMonetarySummation
unece:specifiedTransportInstructions
unece:specifiedTransportPerson
unece:specifiedValidationStatus
unece:subordinateSubordinateSubordinateLocation
unece:telephoneTelecommunicationCommunication
```
That also reduced the number of classes without references from 32 to 9, because the property type was assigned correctly.