### PR TITLE
Fix id and type

### DIFF
--- a/scripts/transformer/pom.xml
+++ b/scripts/transformer/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>org.unece.uncefact</groupId>
     <artifactId>vocab-transformer</artifactId>
-    <version>1.0.0-rc10</version>
+    <version>1.0.0-rc11</version>
     <build>
         <plugins>
             <plugin>

--- a/scripts/transformer/src/main/java/org/unece/uncefact/vocab/Entity.java
+++ b/scripts/transformer/src/main/java/org/unece/uncefact/vocab/Entity.java
@@ -217,7 +217,13 @@ public class Entity {
         String propertyKey = getRepresentationTermForNDRRules();
         if (StringUtils.isBlank(getTDED()) || !codes.contains(getTDED())) {
             propertyKey = StringUtils.join(getPropertyTermWithQualifierForNDRRules(), propertyKey);
-            if (!StringUtils.isBlank(getAssociatedObjectClass())) {
+            // https://github.com/uncefact/spec-jsonld/issues/144#issuecomment-1333493717
+            // as type is widely used as an alias for @type in JSON-LD
+            // it was agreed to rename split `type` property
+            if (propertyKey.equalsIgnoreCase("type")){
+                propertyKey = StringUtils.join(getObjectClassTerm(), propertyKey);
+            }
+            else if (!StringUtils.isBlank(getAssociatedObjectClass())) {
                 propertyKey = StringUtils.join(propertyKey, getAssociatedObjectClass());
             }
         } else {
@@ -250,7 +256,12 @@ public class Entity {
             if(!StringUtils.startsWithIgnoreCase(propertyKey, split[i]))
                 propertyKey = StringUtils.join(split[i], propertyKey);
         }
-
+        // https://github.com/uncefact/spec-jsonld/issues/144#issuecomment-1333493717
+        // as id is widely used as an alias for @id in JSON-LD
+        // it was agreed to rename `id` property to `identifier`
+        if (propertyKey.equalsIgnoreCase("id")){
+            propertyKey = "identifier";
+        }
         return propertyKey;
     }
 


### PR DESCRIPTION
This PR includes the fix for https://github.com/uncefact/spec-jsonld/issues/144#issuecomment-1333493717

Diff report:

```
Classes that exists in set1 but missing in set2 (were removed from set2) - 0:
Classes that exists in set2 but missing in set1 (were added to set2) - 0:
Properties that exists in set1 but missing in set2 (were removed from set2) - 2:
unece:id
unece:type
Properties that exists in set2 but missing in set1 (were added to set2) - 7:
unece:identifier
unece:packagingType
unece:priceType
unece:routeType
unece:taxType
unece:transportMeansType
unece:transportMovementType
```